### PR TITLE
feat: expanded http server to redirect failed messages and added probes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,10 +3,9 @@ name: Create, test (Kind) and publish a Docker image
 
 on:
   workflow_dispatch:
-  push:
+  pull_request:
 
-
-# Registry and repository used to name the image
+    
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM google/cloud-sdk:slim
 RUN useradd -ms /bin/bash bucketup
 
 COPY docker/run.sh /home/bucketup/run.sh
-COPY server.py /home/bucketup/server.py
+COPY docker/server.py /home/bucketup/server.py
 RUN chown bucketup:bucketup /home/bucketup/run.sh
 RUN chmod +x /home/bucketup/run.sh
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,6 +3,7 @@ FROM google/cloud-sdk:slim
 RUN useradd -ms /bin/bash bucketup
 
 COPY docker/run.sh /home/bucketup/run.sh
+COPY server.py /home/bucketup/server.py
 RUN chown bucketup:bucketup /home/bucketup/run.sh
 RUN chmod +x /home/bucketup/run.sh
 

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -13,6 +13,6 @@ mkdir -p content
 gsutil -m rsync -r "gs://$BUCKET_NAME" content
 
 # Start a simple HTTP server to serve the content
-cd content
-ls -la
-python3 -m http.server 8080 --bind 0.0.0.0
+ls -la content
+
+python3 server.py

--- a/docker/server.py
+++ b/docker/server.py
@@ -3,37 +3,35 @@ from http.server import SimpleHTTPRequestHandler, HTTPServer
 
 CONTENT_DIR = 'content'
 
-# Common index file names to look for
-INDEX_NAMES = ["index.html", "index.htm", "default.html", "default.htm"]
-
-def find_index_file():
-    for name in INDEX_NAMES:
-        index_path = os.path.join(CONTENT_DIR, name)
-        if os.path.isfile(index_path):
-            return name
-    return None
-
-INDEX_FILE = find_index_file()
-if not INDEX_FILE:
-    raise FileNotFoundError(f"No index file found in {CONTENT_DIR}")
 
 class CustomHandler(SimpleHTTPRequestHandler):
     def translate_path(self, path):
-        """Serve files from CONTENT_DIR instead of the current directory."""
-        # Strip query string or fragment
+        # Strip query string/fragment and normalize
         path = path.split('?', 1)[0].split('#', 1)[0]
         path = os.path.normpath(path.lstrip('/'))
         return os.path.join(CONTENT_DIR, path)
 
     def do_GET(self):
+        # Health check endpoint
+        if self.path == "/healthz":
+            self.send_response(200)
+            self.send_header("Content-type", "text/plain")
+            self.end_headers()
+            self.wfile.write(b"ok\n")
+            return
+
         requested_path = self.translate_path(self.path)
-        if not os.path.exists(requested_path) or os.path.isdir(requested_path):
-            # Serve index file when path not found or is a directory
-            self.path = '/' + INDEX_FILE
+        if not os.path.exists(requested_path):
+            # Redirect to root for unknown paths
+            self.send_response(302)
+            self.send_header('Location', '/')
+            self.end_headers()
+            return
+
         return super().do_GET()
 
+
 if __name__ == "__main__":
-    # If no content directory exists, error out
     if not os.path.exists(CONTENT_DIR):
         raise FileNotFoundError(f"Content directory '{CONTENT_DIR}' does not exist.")
 

--- a/docker/server.py
+++ b/docker/server.py
@@ -1,0 +1,43 @@
+import os
+from http.server import SimpleHTTPRequestHandler, HTTPServer
+
+CONTENT_DIR = 'content'
+
+# Common index file names to look for
+INDEX_NAMES = ["index.html", "index.htm", "default.html", "default.htm"]
+
+def find_index_file():
+    for name in INDEX_NAMES:
+        index_path = os.path.join(CONTENT_DIR, name)
+        if os.path.isfile(index_path):
+            return name
+    return None
+
+INDEX_FILE = find_index_file()
+if not INDEX_FILE:
+    raise FileNotFoundError(f"No index file found in {CONTENT_DIR}")
+
+class CustomHandler(SimpleHTTPRequestHandler):
+    def translate_path(self, path):
+        """Serve files from CONTENT_DIR instead of the current directory."""
+        # Strip query string or fragment
+        path = path.split('?', 1)[0].split('#', 1)[0]
+        path = os.path.normpath(path.lstrip('/'))
+        return os.path.join(CONTENT_DIR, path)
+
+    def do_GET(self):
+        requested_path = self.translate_path(self.path)
+        if not os.path.exists(requested_path) or os.path.isdir(requested_path):
+            # Serve index file when path not found or is a directory
+            self.path = '/' + INDEX_FILE
+        return super().do_GET()
+
+if __name__ == "__main__":
+    # If no content directory exists, error out
+    if not os.path.exists(CONTENT_DIR):
+        raise FileNotFoundError(f"Content directory '{CONTENT_DIR}' does not exist.")
+
+    port = 8080
+    print(f"Serving {CONTENT_DIR} on port {port}")
+    with HTTPServer(("", port), CustomHandler) as httpd:
+        httpd.serve_forever()

--- a/values.yaml
+++ b/values.yaml
@@ -23,6 +23,12 @@ containers:
       limits:
         memory: 512Mi
         cpu: 1
+    readinessProbe:
+      httpGet: /healthz
+      initialDelaySeconds: 5
+    livenessProbe:
+      httpGet: /healthz
+      initialDelaySeconds: 5
     ports:
       - name: http
         containerPort: 8080


### PR DESCRIPTION
This pull request introduces a custom Python HTTP server for serving bucket content, adds health check endpoints, and updates the deployment configuration to support Kubernetes readiness and liveness probes. The main changes are the addition of the new server script, improved health monitoring, and updates to the startup process.

**Server Implementation and Startup Changes**
* Added a new custom server script `server.py` that serves files from the `content` directory, handles health checks at `/healthz`, and redirects unknown paths to the root. (`docker/server.py`)
* Updated the Dockerfile to copy `server.py` into the image. (`docker/Dockerfile`)
* Modified the startup script to use the new server instead of the default Python HTTP server, and adjusted directory listing commands. (`docker/run.sh`)

**Health Checks and Kubernetes Integration**
* Added readiness and liveness probes to the deployment configuration, using the new `/healthz` endpoint for health monitoring. (`values.yaml`)