### PR TITLE
fix: better handling of healthz

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -70,6 +70,8 @@ jobs:
           kubectl -n test get deployments
           # Get all logs for the bucketup deployment
           kubectl -n test logs deployment/bucketup --all-containers=true
+          # Do the health check manually
+          curl -sfS http://127.0.0.1:8080/healthz                    
           # Test the service
           curl -sv http://127.0.0.1:8080/ --max-time 10 -o /dev/null
 

--- a/docker/server.py
+++ b/docker/server.py
@@ -1,41 +1,72 @@
 import os
 from http.server import SimpleHTTPRequestHandler, HTTPServer
+from urllib.parse import urlsplit
 
 CONTENT_DIR = 'content'
+PORT = 8080
 
+
+def _is_health(path: str) -> bool:
+    # Accept /healthz, /healthz/, and /healthz?...
+    parts = urlsplit(path)  # strips query/fragment cleanly
+    p = parts.path.rstrip('/')
+    return p == "/healthz"
 
 class CustomHandler(SimpleHTTPRequestHandler):
+    # Ensure we always serve from CONTENT_DIR
     def translate_path(self, path):
-        # Strip query string/fragment and normalize
-        path = path.split('?', 1)[0].split('#', 1)[0]
-        path = os.path.normpath(path.lstrip('/'))
-        return os.path.join(CONTENT_DIR, path)
+        parts = urlsplit(path)
+        # normalize path without leading slash
+        clean = os.path.normpath(parts.path.lstrip('/'))
+        return os.path.join(CONTENT_DIR, clean)
+
+    # Health response writer used by GET/HEAD
+    def _write_health(self, head_only: bool):
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain; charset=utf-8")
+        body = b"ok\n"
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        if not head_only:
+            self.wfile.write(body)
+
+    def do_HEAD(self):
+        if _is_health(self.path):
+            return self._write_health(head_only=True)
+        # For HEAD on static files, fall back to parent
+        return super().do_HEAD()
 
     def do_GET(self):
-        # Health check endpoint
-        if self.path == "/healthz":
-            self.send_response(200)
-            self.send_header("Content-type", "text/plain")
-            self.end_headers()
-            self.wfile.write(b"ok\n")
-            return
+        # Health check first, accept variants
+        if _is_health(self.path):
+            return self._write_health(head_only=False)
 
+        # Resolve requested file
         requested_path = self.translate_path(self.path)
-        if not os.path.exists(requested_path):
-            # Redirect to root for unknown paths
-            self.send_response(302)
-            self.send_header('Location', '/')
-            self.end_headers()
-            return
 
-        return super().do_GET()
+        if os.path.isdir(requested_path):
+            # Serve index.html from a directory if present
+            for name in ("index.html", "index.htm", "default.html", "default.htm"):
+                index_path = os.path.join(requested_path, name)
+                if os.path.exists(index_path):
+                    self.path = os.path.join(self.path.rstrip('/'), name)
+                    return super().do_GET()
 
+        if os.path.exists(requested_path):
+            return super().do_GET()
+
+        # SPA fallback: serve root index.html when route isn't a real file
+        spa_index = os.path.join(CONTENT_DIR, "index.html")
+        if os.path.exists(spa_index):
+            self.path = "/index.html"
+            return super().do_GET()
+
+        # If no SPA index, return 404
+        self.send_error(404, "File not found")
 
 if __name__ == "__main__":
     if not os.path.exists(CONTENT_DIR):
         raise FileNotFoundError(f"Content directory '{CONTENT_DIR}' does not exist.")
-
-    port = 8080
-    print(f"Serving {CONTENT_DIR} on port {port}")
-    with HTTPServer(("", port), CustomHandler) as httpd:
+    print(f"Serving {CONTENT_DIR} on port {PORT}")
+    with HTTPServer(("", PORT), CustomHandler) as httpd:
         httpd.serve_forever()

--- a/values.yaml
+++ b/values.yaml
@@ -1,5 +1,7 @@
 bucketName: "bucketup-sample"
 
+replicaCount: 2
+
 service:
   - name: service
     type: ClusterIP


### PR DESCRIPTION
This pull request refactors and enhances the static file server in `docker/server.py`. The main improvements include robust health check handling, better support for single-page applications (SPA), and improved directory index serving. The code is also cleaned up for clarity and maintainability.

**Health check improvements:**

* Added a dedicated `_is_health` function to robustly detect health check requests, supporting `/healthz`, `/healthz/`, and `/healthz?…` variants. Health checks now respond consistently for both GET and HEAD requests with proper headers and body.

**Static file and SPA serving enhancements:**

* Improved directory handling to automatically serve `index.html` or similar files when a directory is requested.
* Added SPA fallback: when a requested route does not match a file, the server now serves the root `index.html` if present, enabling client-side routing for single-page apps.
* If no SPA index is available, the server returns a 404 error for unknown paths.

**General code cleanup:**

* Refactored path normalization and query/fragment stripping using `urllib.parse.urlsplit` for more reliable request handling.
* Consolidated port configuration and improved startup messaging. (F008f0eaL1